### PR TITLE
ipq806x: 6.1: restore missing dts for Netgear XR450

### DIFF
--- a/target/linux/ipq806x/files-6.1/arch/arm/boot/dts/qcom-ipq8065-xr450.dts
+++ b/target/linux/ipq806x/files-6.1/arch/arm/boot/dts/qcom-ipq8065-xr450.dts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq8065-nighthawk.dtsi"
+
+/ {
+	model = "Netgear Nighthawk XR450";
+	compatible = "netgear,xr450", "qcom,ipq8065", "qcom,ipq8064";
+
+};
+
+&leds {
+	usb1 {
+		label = "white:usb1";
+		gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
+	};
+
+	usb2 {
+		label = "white:usb2";
+		gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&partitions {
+	partition@1880000 {
+		label = "ubi";
+		reg = <0x1880000 0xce00000>;
+	};
+
+	partition@e680000 {
+		label = "reserve";
+		reg = <0xe680000 0x0780000>;
+		read-only;
+	};
+};
+
+&wifi0 {
+	nvmem-cells = <&macaddr_art_c>, <&precal_art_1000>;
+	nvmem-cell-names = "mac-address", "pre-calibration";
+};
+
+&wifi1 {
+	nvmem-cells = <&macaddr_art_0>, <&precal_art_5000>;
+	nvmem-cell-names = "mac-address", "pre-calibration";
+};
+
+&art {
+	macaddr_art_c: macaddr@c {
+		reg = <0xc 0x6>;
+	};
+};


### PR DESCRIPTION
In pushing and refreshing 6.1 pull request, dbac8e8819dd ("ipq806x: 6.1: copy patches, files and config from 5.15") wasn't correctly updated and resulted in missing the dts for Netgear XR450. This caused compilation error with Netgear R7800 or XR500 if testing kernel version was used.

Fix this by adding back the missing dts for Netgear XR450 from kernel 5.15.

Fixes: dbac8e8819dd ("ipq806x: 6.1: copy patches, files and config from 5.15")

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
